### PR TITLE
Add linting to PR

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -1,0 +1,29 @@
+#  Copyright (c) University College London Hospitals NHS Foundation Trust
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+---
+  name: PR checks
+  
+  on: [pull_request]
+  
+  jobs:
+    lint:
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@v2
+      - name: lint
+        # run dockerhub version so we don't build the container during the check https://github.com/marketplace/actions/psscriptanalyzer-checks
+        uses: docker://devblackops/github-action-psscriptanalyzer:2.3.0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+  


### PR DESCRIPTION
Doesn't look like github action has been updated in a while, let me know if you'd prefer I look for an alternative (quick check didn't find much, but figured it'd be better to have some linting and then iterate)

[MegaLinter](https://github.com/marketplace/actions/megalinter) looks it it could be an option but seems like it does a lot more than what we'd want from a quick scan (example GHA seems to create PRs for fixes, rather than linting during a PR)